### PR TITLE
fix: error on import Keycloak module in guards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-keycloak-connect",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
-import KeycloakConnect from 'keycloak-connect';
+import { Keycloak } from 'keycloak-connect';
 import { KEYCLOAK_INSTANCE } from '../constants';
 
 /**
@@ -16,7 +16,7 @@ import { KEYCLOAK_INSTANCE } from '../constants';
 export class AuthGuard implements CanActivate {
   constructor(
     @Inject(KEYCLOAK_INSTANCE)
-    private keycloak: KeycloakConnect.Keycloak,
+    private keycloak: Keycloak,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/src/guards/resource.guard.ts
+++ b/src/guards/resource.guard.ts
@@ -7,7 +7,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import KeycloakConnect from 'keycloak-connect';
+import { Keycloak } from 'keycloak-connect';
 import { KEYCLOAK_INSTANCE } from '../constants';
 
 // Temporary until keycloak-connect can have full typescript definitions
@@ -31,7 +31,7 @@ export class ResourceGuard implements CanActivate {
 
   constructor(
     @Inject(KEYCLOAK_INSTANCE)
-    private keycloak: KeycloakConnect.Keycloak,
+    private keycloak: Keycloak,
     private readonly reflector: Reflector,
   ) {}
 
@@ -82,7 +82,7 @@ export class ResourceGuard implements CanActivate {
 }
 
 const createEnforcerContext = (request: any, response: any) => (
-  keycloak: KeycloakConnect.Keycloak,
+  keycloak: Keycloak,
   permissions: string[],
 ) =>
   new Promise<boolean>((resolve, reject) =>


### PR DESCRIPTION
I got such an error, although I did everything according to the documentation

![image](https://user-images.githubusercontent.com/21336829/77145885-2ddea180-6aa3-11ea-8236-89cf16f2d15b.png)

In the `keycloak-connect` module, exporting an instance of Keycloak is not by default, but is imported as default.

It could be imported as `import * as KeycloakConnect from 'keycloak-connect'` but I like my option more