### PR TITLE
chore: Import APP_GUARD in app.module.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Register the module in app.module.ts
 
 ```typescript
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import {
   KeycloakConnectModule,
   ResourceGuard,


### PR DESCRIPTION
When copying the example in `README.md`, beginners might not be aware that `APP_GUARD` needs to be imported or where to import it from, hence dealing with the error: `Cannot find name 'APP_GUARD'`
Adding the import helps a developer get started with the library faster.

Reference: [https://docs.nestjs.com/guards#binding-guards](https://docs.nestjs.com/guards#binding-guards)