### PR TITLE
1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Nest Keycloak Connect
 
+![License](https://badgen.net/npm/license/nest-keycloak-connect)
+[![Package Version](https://badgen.net/npm/v/nest-keycloak-connect)](https://www.npmjs.com/package/nest-keycloak-connect)
 [![Build Status](https://travis-ci.com/ferrerojosh/nest-keycloak-connect.svg?branch=master)](https://travis-ci.com/ferrerojosh/nest-keycloak-connect)
+![Weekly Download](https://badgen.net/npm/dw/nest-keycloak-connect)
+![Total Download](https://badgen.net/npm/dt/nest-keycloak-connect)
 
 > An adapter for [keycloak-nodejs-connect](https://github.com/keycloak/keycloak-nodejs-connect).
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ export class AppModule {}
 In your controllers, simply do:
 
 ```typescript
-import { Resource, Roles, Scopes, AllowAnyRole } from 'nest-keycloak-connect';
+import { Resource, Roles, Scopes, AllowAnyRole, Unprotected, Public } from 'nest-keycloak-connect';
 import { Controller, Get, Delete, Put, Post, Param } from '@nestjs/common';
 import { Product } from './product';
 import { ProductService } from './product.service';
@@ -94,8 +94,9 @@ import { ProductService } from './product.service';
 export class ProductController {
   constructor(private service: ProductService) {}
 
+  // New in 1.2.0, allows you add unprotected/public routes
   @Get()
-  @Scopes('View', 'View All')
+  @Unprotected() // Use `@Public` if the verb seems weird to you
   async findAll() {
     return await this.service.findAll();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-keycloak-connect",
-  "version": "1.3.0-alpha.01",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -182,6 +182,32 @@
         "@types/node": "13.13.5"
       }
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "optional": true,
+      "requires": {
+        "debug": "4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "optional": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "optional": true
+        }
+      }
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -220,9 +246,9 @@
       "optional": true
     },
     "asn1.js": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
-      "integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "requires": {
         "bn.js": "4.11.9",
         "inherits": "2.0.4",
@@ -292,20 +318,6 @@
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
         "supports-color": "5.5.0"
-      }
-    },
-    "chromedriver": {
-      "version": "83.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-83.0.0.tgz",
-      "integrity": "sha512-AePp9ykma+z4aKPRqlbzvVlc22VsQ6+rgF+0aL3B5onHOncK18dWSkLrSSJMczP/mXILN9ohGsvpuTwoRSj6OQ==",
-      "optional": true,
-      "requires": {
-        "@testim/chrome-version": "1.0.7",
-        "axios": "0.19.2",
-        "del": "5.1.0",
-        "extract-zip": "2.0.1",
-        "mkdirp": "1.0.4",
-        "tcp-port-used": "1.0.1"
       }
     },
     "clean-stack": {
@@ -442,9 +454,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "4.11.9",
         "brorand": "1.1.0",
@@ -707,6 +719,33 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "optional": true,
+      "requires": {
+        "agent-base": "6.0.2",
+        "debug": "4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "optional": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "optional": true
+        }
+      }
+    },
     "ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -800,22 +839,39 @@
       "dev": true
     },
     "jwk-to-pem": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.3.tgz",
-      "integrity": "sha512-T1MA0L3DVB2mOIZytZyNTdcAAOJscLLCi25dgzQtkHjTcuwpRW3BFnjj0eEpMORfJyZtFZ5wy++Ys6wsMolPsA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.4.tgz",
+      "integrity": "sha512-4CCK9UBHNWjWtfSHdyu3I6rA8vlN5cWqnVuwY0cOMyXtw6M1tP+yrM8GZpwk+P932Dc3cLag4d35B6CqyIf89A==",
       "requires": {
-        "asn1.js": "5.3.0",
-        "elliptic": "6.5.2",
+        "asn1.js": "5.4.1",
+        "elliptic": "6.5.3",
         "safe-buffer": "5.2.1"
       }
     },
     "keycloak-connect": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-10.0.0.tgz",
-      "integrity": "sha512-8jA9ngGfaVO1JwuuOXVffwz8nB4sTcsSuhiwIsHb0SK8vmWis8M97T0MGPtsxe+p1pHeYWdJdrDCAI9z474sNg==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-11.0.3.tgz",
+      "integrity": "sha512-VVmdiRFXRJmik1Py/cGplySsVeGcLjGpoYoC4VW5b9meCcVTN4jFAokYup7Nkba6L9SM+NNQD6brlG5DZeHiWg==",
       "requires": {
-        "chromedriver": "83.0.0",
-        "jwk-to-pem": "2.0.3"
+        "chromedriver": "87.0.1",
+        "jwk-to-pem": "2.0.4"
+      },
+      "dependencies": {
+        "chromedriver": {
+          "version": "87.0.1",
+          "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-87.0.1.tgz",
+          "integrity": "sha512-tSvCV0pj47Sv2xTudV5IffLE50y7D4T1TWHzAAvN362rcetqJk0GipMO79kwZ5/muvIePRjQ1zXjOwS/8qzfFA==",
+          "optional": true,
+          "requires": {
+            "@testim/chrome-version": "1.0.7",
+            "axios": "0.19.2",
+            "del": "5.1.0",
+            "extract-zip": "2.0.1",
+            "https-proxy-agent": "5.0.0",
+            "mkdirp": "1.0.4",
+            "tcp-port-used": "1.0.1"
+          }
+        }
       }
     },
     "lru-queue": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-keycloak-connect",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "keycloak-nodejs-connect module for Nest",
   "author": "John Joshua Ferrer <johnjoshuaferrer@disroot.org>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "nest-keycloak-connect",
-  "version": "1.3.0-alpha.03",
+  "version": "1.3.0",
   "description": "keycloak-nodejs-connect module for Nest",
   "author": "John Joshua Ferrer <johnjoshuaferrer@disroot.org>",
   "contributors": [
     "IERomanov <i.e.romanov1997@gmail.com>",
     "Jeff Tian <jeff.tian@outlook.com>",
-    "EFritzsche90"
+    "EFritzsche90",
+    "abiodunsulaiman694 <hello@abiodun.dev>"
   ],
   "license": "MIT",
   "scripts": {
@@ -35,7 +36,7 @@
     "rxjs": "^6.0.0"
   },
   "dependencies": {
-    "keycloak-connect": "^10.0.0"
+    "keycloak-connect": "^11.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-keycloak-connect",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "keycloak-nodejs-connect module for Nest",
   "author": "John Joshua Ferrer <johnjoshuaferrer@disroot.org>",
   "contributors": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,9 @@
+/**
+ * Used internally, provides keycloak options for the Nest guards.
+ */
 export const KEYCLOAK_CONNECT_OPTIONS = 'KEYCLOAK_CONNECT_OPTIONS';
 
+/**
+ * Key for injecting a keycloak instance.
+ */
 export const KEYCLOAK_INSTANCE = 'KEYCLOAK_INSTANCE';

--- a/src/decorators/unprotected.decorator.ts
+++ b/src/decorators/unprotected.decorator.ts
@@ -1,16 +1,24 @@
 import { SetMetadata } from '@nestjs/common';
 
 export const META_UNPROTECTED = 'unprotected';
+export const META_SKIP_AUTH = 'skip-auth';
 
 /**
  * Allow user to use unprotected routes.
  * @since 1.2.0
+ * @param skipAuth attaches authorization header to user object when `false`, defaults to `true`
  */
-export const Unprotected = () => SetMetadata(META_UNPROTECTED, true);
+export const Unprotected = (skipAuth = true) => {
+    SetMetadata(META_UNPROTECTED, true);
+    SetMetadata(META_SKIP_AUTH, skipAuth);
+}
 
 /**
  * Alias for `@Unprotected`.
  * @since 1.2.0
+ * @param skipAuth attaches authorization header to user object when `false`, defaults to `true`
  */
-
-export const Public = () => SetMetadata(META_UNPROTECTED, true);
+export const Public = (skipAuth = true) => {
+    SetMetadata(META_UNPROTECTED, true);
+    SetMetadata(META_SKIP_AUTH, skipAuth);
+}

--- a/src/decorators/unprotected.decorator.ts
+++ b/src/decorators/unprotected.decorator.ts
@@ -4,10 +4,12 @@ export const META_UNPROTECTED = 'unprotected';
 
 /**
  * Allow user to use unprotected routes.
+ * @since 1.2.0
  */
 export const Unprotected = () => SetMetadata(META_UNPROTECTED, true);
 
 /**
  * Alias for `@Unprotected`.
+ * @since 1.2.0
  */ 
 export const Public = () => SetMetadata(META_UNPROTECTED, true);

--- a/src/decorators/unprotected.decorator.ts
+++ b/src/decorators/unprotected.decorator.ts
@@ -4,9 +4,10 @@ export const META_UNPROTECTED = 'unprotected';
 
 /**
  * Allow user to use unprotected routes.
- * @param unprotected - Flag to identidy routes which do not need protection
  */
-
-
 export const Unprotected = () => SetMetadata(META_UNPROTECTED, true);
 
+/**
+ * Alias for `@Unprotected`.
+ */ 
+export const Public = () => SetMetadata(META_UNPROTECTED, true);

--- a/src/decorators/unprotected.decorator.ts
+++ b/src/decorators/unprotected.decorator.ts
@@ -9,9 +9,9 @@ export const META_SKIP_AUTH = 'skip-auth';
  * @param skipAuth attaches authorization header to user object when `false`, defaults to `true`
  */
 export const Unprotected = (skipAuth = true) => {
-    SetMetadata(META_UNPROTECTED, true);
-    SetMetadata(META_SKIP_AUTH, skipAuth);
-}
+  SetMetadata(META_UNPROTECTED, true);
+  SetMetadata(META_SKIP_AUTH, skipAuth);
+};
 
 /**
  * Alias for `@Unprotected`.
@@ -19,6 +19,6 @@ export const Unprotected = (skipAuth = true) => {
  * @param skipAuth attaches authorization header to user object when `false`, defaults to `true`
  */
 export const Public = (skipAuth = true) => {
-    SetMetadata(META_UNPROTECTED, true);
-    SetMetadata(META_SKIP_AUTH, skipAuth);
-}
+  SetMetadata(META_UNPROTECTED, true);
+  SetMetadata(META_SKIP_AUTH, skipAuth);
+};

--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -59,22 +59,18 @@ export class AuthGuard implements CanActivate {
   }
 
   extractJwt(headers: { [key: string]: string }) {
-    if (headers) {
-      if (!headers.authorization) {
-        throw new UnauthorizedException();
-      }
-
-      const auth = headers.authorization.split(' ');
-
-      // We only allow bearer
-      if (auth[0].toLowerCase() !== 'bearer') {
-        throw new UnauthorizedException();
-      }
-
-      return auth[1];
-    } else {
+    if (headers && !headers.authorization) {
       throw new UnauthorizedException();
     }
+
+    const auth = headers.authorization.split(' ');
+
+    // We only allow bearer
+    if (auth[0].toLowerCase() !== 'bearer') {
+      throw new UnauthorizedException();
+    }
+
+    return auth[1];
   }
 
   extractJwtFromCookie(cookies: { [key: string]: string }) {

--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -9,7 +9,10 @@ import * as KeycloakConnect from 'keycloak-connect';
 import { KEYCLOAK_INSTANCE, KEYCLOAK_CONNECT_OPTIONS } from '../constants';
 import { KeycloakConnectOptions } from '../interface/keycloak-connect-options.interface';
 import { Reflector } from '@nestjs/core';
-import { META_SKIP_AUTH, META_UNPROTECTED } from '../decorators/unprotected.decorator';
+import {
+  META_SKIP_AUTH,
+  META_UNPROTECTED,
+} from '../decorators/unprotected.decorator';
 
 /**
  * An authentication guard. Will return a 401 unauthorized when it is unable to
@@ -30,10 +33,10 @@ export class AuthGuard implements CanActivate {
       META_UNPROTECTED,
       [context.getClass(), context.getHandler()],
     );
-    const skipAuth = this.reflector.getAllAndOverride<boolean>(
-      META_SKIP_AUTH,
-      [context.getClass(), context.getHandler()],
-    );
+    const skipAuth = this.reflector.getAllAndOverride<boolean>(META_SKIP_AUTH, [
+      context.getClass(),
+      context.getHandler(),
+    ]);
 
     // If unprotected is set skip Keycloak authentication
     if (isUnprotected && skipAuth) {
@@ -44,10 +47,10 @@ export class AuthGuard implements CanActivate {
     const jwt =
       this.extractJwtFromCookie(request.cookies) ??
       this.extractJwt(request.headers);
-    const isInvalidJwt = (jwt === null || jwt === undefined);
+    const isInvalidJwt = jwt === null || jwt === undefined;
 
     // Auth is not skipped, but no jwt token given, immediate return
-    if(isUnprotected && isInvalidJwt) {
+    if (isUnprotected && isInvalidJwt) {
       return true;
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "declaration": true,
-    "removeComments": true,
+    "removeComments": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "target": "es6",


### PR DESCRIPTION
A minor release with a few changes.

- `@Unprotected/@Public` should now be available at the controller-level.
- `@Unprotected/@Public` now have an optional parameter `skipAuth` that is set to true by default, when false, a jwt header is checked, and will be authenticated on a public route
- Bump `keycloak-connect` version to `^11.0.0`