### PR TITLE
docs: updated readme for realm roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export class ProductController {
 
   // New in 1.1.0, allows you to set roles
   @Get()
-  @Roles('master:admin', 'myrealm:admin', 'admin')
+  @Roles('realm:admin', 'admin')
   // Optional, allows any role passed in `@Roles` to be permitted
   @AllowAnyRole()
   async findAllBarcodes() {


### PR DESCRIPTION
While working with this library I was always stuck using realm roles. It was never working according to the docs. I took a look in to the keycloak docs (http://www.keycloak.org/keycloak-nodejs-auth-utils/token.js.html)  and it revealed, that 

```typescript
token.hasRole(role)
```
needs the word 'realm' as prefix and not your realm name. Therefore i updated the readme.
To avoid confusion in the future, one could think about a dedicated decorator @RealmRole or something like that..

cheers