### PR TITLE
fix: read property 'roles' of undefined when before check

### DIFF
--- a/src/guards/role.guard.ts
+++ b/src/guards/role.guard.ts
@@ -35,8 +35,6 @@ export class RoleGuard implements CanActivate {
       RoleDecoratorOptionsInterface
     >(META_ROLES, [context.getClass(), context.getHandler()]);
 
-    const rolesStr = JSON.stringify(rolesMetaData.roles);
-
     if (!rolesMetaData || rolesMetaData.roles.length === 0) {
       return true;
     }
@@ -45,6 +43,7 @@ export class RoleGuard implements CanActivate {
       rolesMetaData.mode = RoleMatchingMode.ANY;
     }
 
+    const rolesStr = JSON.stringify(rolesMetaData.roles);
     this.logger.verbose(`Roles: ${rolesStr}`);
 
     // Extract request


### PR DESCRIPTION
I found this error in my project.

 Cannot read property 'roles' of undefined

 I verified that it is trying to read a property before its 
verification that may have an undefined value.