### PR TITLE
fix: cannot find provider 'KeycloakMultiTenantService' when setting u…

### DIFF
--- a/src/keycloak-connect.module.ts
+++ b/src/keycloak-connect.module.ts
@@ -74,6 +74,7 @@ export class KeycloakConnectModule {
       this.createAsyncOptionsProvider(options),
       loggerProvider,
       keycloakProvider,
+      KeycloakMultiTenantService,
     ];
 
     if (options.useExisting || options.useFactory) {


### PR DESCRIPTION
It seems `KeycloakMultiTenantService` is missing the for the `createAsyncProviders` causing the issue.  

related #93 

Have tested with my own fork for the company and it seems to be working with that fix.