### PR TITLE
feat: use @Resource decorator without @Scopes decorator on method 

### DIFF
--- a/src/guards/resource.guard.ts
+++ b/src/guards/resource.guard.ts
@@ -92,7 +92,9 @@ export class ResourceGuard implements CanActivate {
     );
 
     // Build permissions
-    const permissions = scopes.map(scope => `${resource}:${scope}`);
+    const permissions = scopes?.map(scope => `${resource}:${scope}`) ?? [
+      resource,
+    ];
     // Extract request/response
     const [request, response] = extractRequest(context);
 

--- a/src/guards/resource.guard.ts
+++ b/src/guards/resource.guard.ts
@@ -75,16 +75,9 @@ export class ResourceGuard implements CanActivate {
 
     // No scopes given, check policy enforcement mode
     if (!scopes) {
-      if (shouldAllow) {
-        this.logger.verbose(
-          `Route has no @Scope defined, request allowed due to policy enforcement`,
-        );
-      } else {
-        this.logger.verbose(
-          `Route has no @Scope defined, request denied due to policy enforcement`,
-        );
-      }
-      return shouldAllow;
+      this.logger.verbose(
+        `Route has no @Scope defined, request denied due to policy enforcement`,
+      );
     }
 
     this.logger.verbose(


### PR DESCRIPTION
Hello, love the project! 😃 

I was poking around the [keycloak-nodejs adapter](https://github.com/keycloak/keycloak-nodejs-connect/blob/f8e011aea5021b81cd085df078eee7b5d773d0cc/middleware/enforcer.js#L58)  and with a bit of trial and error made work the resource base access control option without specifying any scope.

Wanting to integrate keycloak with Nest.js I found your NPM package but I wasn't able to use the `@Resource('resource_name')` decorator without also using the `@Scopes('scope_name')` decorator as well so I thought that maybe this PR could fix that.

Don't know if this is best practice or not with keycloak to have authorization on a resource without any scope, but this changed allowed me to just that.

If it isn't best practice then never mind, sorry for the bother
