### PR TITLE
Enable secret per realm configuration

### DIFF
--- a/src/interface/keycloak-connect-options.interface.ts
+++ b/src/interface/keycloak-connect-options.interface.ts
@@ -171,4 +171,9 @@ export interface KeycloakCredentials {
    * Client/Application secret.
    */
   secret: string;
+
+  /**
+   * Client/Application secrets mapped per realm
+   */
+  realmSecretMap?: Map<string, string>;
 }

--- a/src/services/keycloak-multitenant.service.ts
+++ b/src/services/keycloak-multitenant.service.ts
@@ -30,11 +30,7 @@ export class KeycloakMultiTenantService {
 
       // Override secret
       const creds = keycloakOpts.credentials;
-      if (
-        creds !== undefined &&
-        creds.realmSecretMap !== undefined &&
-        creds.realmSecretMap.has(realm)
-      ) {
+      if(creds?.realmSecretMap?.has(realm)) {
         keycloakOpts.secret = keycloakOpts.credentials.realmSecretMap[realm];
       } // else it it will default to global secret
 

--- a/src/services/keycloak-multitenant.service.ts
+++ b/src/services/keycloak-multitenant.service.ts
@@ -27,6 +27,17 @@ export class KeycloakMultiTenantService {
       // TODO: Repeating code from  provider, will need to rework this in 2.0
       // Override realm
       const keycloakOpts: any = Object.assign(this.keycloakOpts, { realm });
+
+      // Override secret
+      const creds = keycloakOpts.credentials;
+      if (
+        creds !== undefined &&
+        creds.realmSecretMap !== undefined &&
+        creds.realmSecretMap.has(realm)
+      ) {
+        keycloakOpts.secret = keycloakOpts.credentials.realmSecretMap[realm];
+      } // else it it will default to global secret
+
       const keycloak: any = new KeycloakConnect({}, keycloakOpts);
 
       // The most important part


### PR DESCRIPTION
In your @ferrerojosh  for: https://github.com/ferrerojosh/nest-keycloak-connect/issues/93 it is not possible to provide separate secrets for each realm.

In order to achieve that `KeycloakCredentials` interface has been extended with map realm:secret + secret patching on creating instance.