### PR TITLE
fix: non HTTP requests are undefined in built-in AuthGuard 

### DIFF
--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -57,6 +57,12 @@ export class AuthGuard implements CanActivate {
 
     // Extract request/response
     const [request] = extractRequest(context);
+
+    // if is not an HTTP request ignore this guard
+    if (!request) {
+      return true;
+    }
+    
     const jwt =
       this.extractJwtFromCookie(request.cookies) ??
       this.extractJwt(request.headers);


### PR DESCRIPTION
Hi all, nice to meet you and these project.

the AuthGuard also comes into operation when requests that are not HTTP arrive such as amqp (rabbit MQ).
In fact, there are modules such as `@golevelup/nestjs-rabbitmq` that provide a decorator that works in a similar way to the http core decorator provided by nest, and therefore subject to middleware.
The module's built-in AuthGuard does not detect the undefined returned by the extractRequest function, causing an exception just after reading request.cookies.

the workaround I found immediately is to use the decorator `@Unprotected()` thus entering the condition `isUnprotected`

The real solution instead could be to insert a simple condition whereby if request is undefined, the guard returns true (because it is out of its competence).

I am therefore sending you a pr with the solution I have undertaken, hoping that from your point of view it can be really decisive

regards