### PR TITLE
add authServerUrlResolver + make realmResolver optional

### DIFF
--- a/src/interface/keycloak-connect-options.interface.ts
+++ b/src/interface/keycloak-connect-options.interface.ts
@@ -20,11 +20,15 @@ export interface MultiTenantOptions {
   /**
    * The realm resolver function.
    */
-  realmResolver: (request: any) => Promise<string> | string;
+  realmResolver?: (request: any) => Promise<string> | string;
   /**
    * The realm secret resolver function.
    */
   realmSecretResolver?: (realm: string) => Promise<string> | string;
+  /**
+   * Auth server url resolver function.
+   */
+  authServerUrlResolver?: (realm: string) => Promise<string> | string;
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,16 +14,21 @@ export const useKeycloak = async (
   multiTenant: KeycloakMultiTenantService,
   opts: KeycloakConnectConfig,
 ): Promise<KeycloakConnect.Keycloak> => {
-  if (opts.multiTenant && opts.multiTenant.realmResolver) {
-    const resolvedRealm = opts.multiTenant.realmResolver(request);
-    const realm =
-      resolvedRealm instanceof Promise ? await resolvedRealm : resolvedRealm;
-    return await multiTenant.get(realm);
-  } else if (!opts.realm) {
+  if (opts.multiTenant) {
+    if (opts.multiTenant.realmResolver) {
+      const resolvedRealm = opts.multiTenant.realmResolver(request);
+      const realm =
+        resolvedRealm instanceof Promise ? await resolvedRealm : resolvedRealm;
+
+      return await multiTenant.get(realm);
+    }
+
     const payload = parseToken(jwt);
     const issuerRealm = payload.iss.split('/').pop();
+
     return await multiTenant.get(issuerRealm);
   }
+
   return singleTenant;
 };
 


### PR DESCRIPTION
Hello, in my project i need authServerUrlResolver with same logic as `realmSecretResolver`. I think it will be useful for other people too.
And i make realmResolver optional + fix logic in `useKeycloak` in utils.ts. If you won't provide realmResolver then it will parse realm from token.