### PR TITLE
peerDependencies upgraded to allow keycloak-connect 25.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@nestjs/common": ">=6.0.0 <11.0.0",
     "@nestjs/core": ">=6.0.0 <11.0.0",
     "@nestjs/graphql": ">=6",
-    "keycloak-connect": ">=10.0.0 <25.0.0"
+    "keycloak-connect": ">=10.0.0 <26.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "^10.3.3",


### PR DESCRIPTION
Despite the package keycloak-connect is deprecated, the team goes on fixing minor bugs. And its version number follow the keycloak main version number. In this case, why to limit people with an older version? I suggest to upgrade the peerDependencies version from 24 to 25. See https://github.com/ferrerojosh/nest-keycloak-connect/issues/189.